### PR TITLE
Update README.md to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tabula Rasa repositories can support Berkshelf. Berkshelf will be invoked if the
 
 To use Tabula Rasa:
 
-1. Use Tabla Rasa `git://github.com/shlomoswidler/tabula_rasa.git` as the Custom Repository URL for your Layer (or for the entire Stack), or include this cookbook in your own custom cookbook repository (perhaps via Berkshelf).
+1. Use Tabla Rasa `git://github.com/shlomoswidler/tabula_rasa.git` as the Custom Repository URL for your Stack, or include this cookbook in your own custom cookbook repository.
 2. Configure your Custom Stack JSON as per [the Configuration section below](#configuration), to specify the repository from which the Tabula Rasa cookbooks are retrieved, and the custom run list for each OpsWorks lifecycle action.
 3. Include the `tabula_rasa` recipe in the OpsWorks Layer's Custom Chef Recipes for each lifecycle action. You can specify other recipes before and after `tabula_rasa` in the Custom Chef Recipes---Tabula Rasa will have no effect on them and they will run normally, as expected, using the custom cookbook repository you specified for this Layer.
 


### PR DESCRIPTION
Remove language about using tabula_rasa repository in only one layer. You can specify that the recipe only be used in one layer, but repositories must be set at the stack level in OpsWorks.

Also, more controversial and less confident, remove reference to including tabula_rasa via Berkshelf. While this may work in some scenario, it has not in the ways I have tried, as there are dependency issues between the Berkshelf included `tabula_rasa` and standard opsworks-cookbooks (see https://github.com/shlomoswidler/tabula_rasa/issues/7).
